### PR TITLE
CDP-405 Changed tag name for environment name

### DIFF
--- a/label_check/entrypoint.sh
+++ b/label_check/entrypoint.sh
@@ -97,7 +97,7 @@ main(){
     echo "...done"
 
     type="action"
-    send_chat_message "$type \"$label_to_check\""
+    send_chat_message "$type \"$DEPLOY_ENVIRONMENT\""
 
     # Check if another PR has deploy or deploy_staging label
     echo ""


### PR DESCRIPTION
Fixed error on deploy start message, actually shows the deployment tag "deploy" or "deploy_staging", but should show "production" or "staging".