### PR TITLE
[MAN-42] Add 'preboot' on heroku deployment.

### DIFF
--- a/firebase_deploy/chat.sh
+++ b/firebase_deploy/chat.sh
@@ -7,6 +7,7 @@ main(){
   type=$1
   environment=$2
   err=$3
+  migration=$4
 
   icon=""
   message=""
@@ -25,7 +26,12 @@ main(){
 
   error_message=""
   if [ "$err" != "" ]; then
-    error_message="Motive:              *${err}*"
+    error_message="Motive:              *${err}*\n"
+  fi
+
+  migration_message=""
+  if [ "$migration" != "" ]; then
+    migration_message="Migration:          *Yes!*\n"
   fi
 
   number=$(jq --raw-output .number ${GITHUB_EVENT_PATH})
@@ -36,7 +42,7 @@ main(){
   chat=$(curl -s -X POST \
     "https://chat.googleapis.com/v1/spaces/${SPACE}/messages?key=${CKEY}&token=${CTOKEN}" \
     -H 'Content-Type: application/json' \
-    -d "{\"text\" : \"${icon} ${message} \nEnvironment:    *${environment}* \nProject:              *${GITHUB_REPOSITORY}* \nPull Request:    *${title}* \nDeployer:           *${GITHUB_ACTOR}* \n${error_message} \"}")
+    -d "{\"text\" : \"${icon} ${message} \nEnvironment:    *${environment}* \nProject:              *${GITHUB_REPOSITORY}* \nPull Request:    *${title}* \nDeployer:           *${GITHUB_ACTOR}* \n${error_message}${migration_message} \"}")
 
 }
 

--- a/firebase_deploy/entrypoint.sh
+++ b/firebase_deploy/entrypoint.sh
@@ -7,8 +7,9 @@ send_chat_message()
   type=$1
   environment=$2
   message=$3
+  migration=$4
 
-  sh -c "$chat_path $type \"$environment\" \"$message\""
+  sh -c "$chat_path $type \"$environment\" \"$message\" \"migration\""
 }
 
 abort()

--- a/gcloud_deploy/chat.sh
+++ b/gcloud_deploy/chat.sh
@@ -7,6 +7,7 @@ main(){
   type=$1
   environment=$2
   err=$3
+  migration=$4
 
   icon=""
   message=""
@@ -25,7 +26,12 @@ main(){
 
   error_message=""
   if [ "$err" != "" ]; then
-    error_message="Motive:              *${err}*"
+    error_message="Motive:              *${err}*\n"
+  fi
+
+  migration_message=""
+  if [ "$migration" != "" ]; then
+    migration_message="Migration:          *Yes!*\n"
   fi
 
   number=$(jq --raw-output .number ${GITHUB_EVENT_PATH})
@@ -36,7 +42,7 @@ main(){
   chat=$(curl -s -X POST \
     "https://chat.googleapis.com/v1/spaces/${SPACE}/messages?key=${CKEY}&token=${CTOKEN}" \
     -H 'Content-Type: application/json' \
-    -d "{\"text\" : \"${icon} ${message} \nEnvironment:    *${environment}* \nProject:              *${GITHUB_REPOSITORY}* \nPull Request:    *${title}* \nDeployer:           *${GITHUB_ACTOR}* \n${error_message} \"}")
+    -d "{\"text\" : \"${icon} ${message} \nEnvironment:    *${environment}* \nProject:              *${GITHUB_REPOSITORY}* \nPull Request:    *${title}* \nDeployer:           *${GITHUB_ACTOR}* \n${error_message}${migration_message} \"}")
 
 }
 

--- a/gcloud_deploy/entrypoint.sh
+++ b/gcloud_deploy/entrypoint.sh
@@ -7,8 +7,9 @@ send_chat_message()
   type=$1
   environment=$2
   message=$3
+  migration=$4
 
-  sh -c "$chat_path $type \"$environment\" \"$message\""
+  sh -c "$chat_path $type \"$environment\" \"$message\" \"migration\""
 }
 
 abort()

--- a/generate_yaml/chat.sh
+++ b/generate_yaml/chat.sh
@@ -7,6 +7,7 @@ main(){
   type=$1
   environment=$2
   err=$3
+  migration=$4
 
   icon=""
   message=""
@@ -25,7 +26,12 @@ main(){
 
   error_message=""
   if [ "$err" != "" ]; then
-    error_message="Motive:              *${err}*"
+    error_message="Motive:              *${err}*\n"
+  fi
+
+  migration_message=""
+  if [ "$migration" != "" ]; then
+    migration_message="Migration:          *Yes!*\n"
   fi
 
   number=$(jq --raw-output .number ${GITHUB_EVENT_PATH})
@@ -36,7 +42,7 @@ main(){
   chat=$(curl -s -X POST \
     "https://chat.googleapis.com/v1/spaces/${SPACE}/messages?key=${CKEY}&token=${CTOKEN}" \
     -H 'Content-Type: application/json' \
-    -d "{\"text\" : \"${icon} ${message} \nEnvironment:    *${environment}* \nProject:              *${GITHUB_REPOSITORY}* \nPull Request:    *${title}* \nDeployer:           *${GITHUB_ACTOR}* \n${error_message} \"}")
+    -d "{\"text\" : \"${icon} ${message} \nEnvironment:    *${environment}* \nProject:              *${GITHUB_REPOSITORY}* \nPull Request:    *${title}* \nDeployer:           *${GITHUB_ACTOR}* \n${error_message}${migration_message} \"}")
 
 }
 

--- a/generate_yaml/entrypoint.sh
+++ b/generate_yaml/entrypoint.sh
@@ -7,8 +7,9 @@ send_chat_message()
   type=$1
   environment=$2
   message=$3
+  migration=$4
 
-  sh -c "$chat_path $type \"$environment\" \"$message\""
+  sh -c "$chat_path $type \"$environment\" \"$message\" \"migration\""
 }
 
 abort()

--- a/heroku_deploy/Dockerfile
+++ b/heroku_deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine/git
+FROM node:alpine
 
 LABEL "com.github.actions.name"="Deploy heroku app"
 LABEL "com.github.actions.description"="Deploys a heroku app"
@@ -15,7 +15,10 @@ RUN	apk add --no-cache \
 	curl \
 	curl-dev \
 	jq \
-	coreutils
+	coreutils \
+	git
+
+RUN curl https://cli-assets.heroku.com/install.sh | sh
 
 ADD chat.sh /chat.sh
 RUN chmod +x /chat.sh

--- a/heroku_deploy/chat.sh
+++ b/heroku_deploy/chat.sh
@@ -7,6 +7,7 @@ main(){
   type=$1
   environment=$2
   err=$3
+  migration=$4
 
   icon=""
   message=""
@@ -25,7 +26,12 @@ main(){
 
   error_message=""
   if [ "$err" != "" ]; then
-    error_message="Motive:              *${err}*"
+    error_message="Motive:              *${err}*\n"
+  fi
+
+  migration_message=""
+  if [ "$migration" != "" ]; then
+    migration_message="Migration:          *Yes!*\n"
   fi
 
   number=$(jq --raw-output .number ${GITHUB_EVENT_PATH})
@@ -36,7 +42,7 @@ main(){
   chat=$(curl -s -X POST \
     "https://chat.googleapis.com/v1/spaces/${SPACE}/messages?key=${CKEY}&token=${CTOKEN}" \
     -H 'Content-Type: application/json' \
-    -d "{\"text\" : \"${icon} ${message} \nEnvironment:    *${environment}* \nProject:              *${GITHUB_REPOSITORY}* \nPull Request:    *${title}* \nDeployer:           *${GITHUB_ACTOR}* \n${error_message} \"}")
+    -d "{\"text\" : \"${icon} ${message} \nEnvironment:    *${environment}* \nProject:              *${GITHUB_REPOSITORY}* \nPull Request:    *${title}* \nDeployer:           *${GITHUB_ACTOR}* \n${error_message}${migration_message} \"}")
 
 }
 

--- a/heroku_deploy/entrypoint.sh
+++ b/heroku_deploy/entrypoint.sh
@@ -7,8 +7,9 @@ send_chat_message()
   type=$1
   environment=$2
   message=$3
+  migration=$4
 
-  sh -c "$chat_path $type \"$environment\" \"$message\""
+  sh -c "$chat_path $type \"$environment\" \"$message\" \"migration\""
 }
 
 abort()
@@ -83,10 +84,15 @@ main(){
     heroku features:enable preboot -a ${app_name}
   fi
 
+  migration_message=""
+  if [ "${WITH_MIGRATION}" = "Y" ]; then
+    migration_message="true"
+  fi
+
   echo "...done"
 
   type="success"
-  send_chat_message "$type \"$environment\""
+  send_chat_message "$type \"$environment\" \"\" \"$migration_message\""
 }
 
 main "$@"

--- a/heroku_deploy/entrypoint.sh
+++ b/heroku_deploy/entrypoint.sh
@@ -71,14 +71,14 @@ main(){
   fi
 
   # The preboot will be always active, only when the label “migration” is present will be disabled.
-  # TODO: Once tested, 'staging_3' must be chenged bye 'production'
+  # TODO: Once tested, 'staging_3' must be changed to 'production'
   if  [ "${DEPLOY_ENVIRONMENT}" = "staging_3" ] && [ "${WITH_MIGRATION}" = "Y" ]; then
     heroku features:disable preboot -a ${app_name}
   fi
 
   git push https://heroku:${HEROKU_API_KEY}@git.heroku.com/${app_name}.git HEAD:master -f
 
-  # TODO: Once tested, 'staging_3' must be chenged bye 'production'
+  # TODO: Once tested, 'staging_3' must be changed to 'production'
   if  [ "${DEPLOY_ENVIRONMENT}" = "staging_3" ] && [ "${WITH_MIGRATION}" = "Y" ]; then
     heroku features:enable preboot -a ${app_name}
   fi

--- a/heroku_deploy/entrypoint.sh
+++ b/heroku_deploy/entrypoint.sh
@@ -72,15 +72,13 @@ main(){
   fi
 
   # The preboot will be always active, only when the label “migration” is present will be disabled.
-  # TODO: Once tested, 'staging_3' must be changed to 'production'
-  if  [ "${DEPLOY_ENVIRONMENT}" = "staging_3" ] && [ "${WITH_MIGRATION}" = "Y" ]; then
+  if  [ "${DEPLOY_ENVIRONMENT}" = "production" ] && [ "${WITH_MIGRATION}" = "Y" ]; then
     heroku features:disable preboot -a ${app_name}
   fi
 
   git push https://heroku:${HEROKU_API_KEY}@git.heroku.com/${app_name}.git HEAD:master -f
 
-  # TODO: Once tested, 'staging_3' must be changed to 'production'
-  if  [ "${DEPLOY_ENVIRONMENT}" = "staging_3" ] && [ "${WITH_MIGRATION}" = "Y" ]; then
+  if  [ "${DEPLOY_ENVIRONMENT}" = "production" ] && [ "${WITH_MIGRATION}" = "Y" ]; then
     heroku features:enable preboot -a ${app_name}
   fi
 

--- a/heroku_deploy/entrypoint.sh
+++ b/heroku_deploy/entrypoint.sh
@@ -51,7 +51,7 @@ main(){
     echo "ERROR"
     exit 1
   fi
-  
+
   if [ "${DEPLOY_ENVIRONMENT}" != "staging" ] && [ "${DEPLOY_ENVIRONMENT}" != "staging_2" ] && [ "${DEPLOY_ENVIRONMENT}" != "staging_3" ] && [ "${DEPLOY_ENVIRONMENT}" != "production" ]; then
     echo "...${DEPLOY_ENVIRONMENT} is not a valid environment"
     echo "ERROR"
@@ -69,8 +69,19 @@ main(){
     app_name=${INPUT_HEROKU_APP_NAME_STAGING_THREE}
 
   fi
-  
-  git push https://heroku:${INPUT_HEROKU_API_KEY}@git.heroku.com/${app_name}.git HEAD:master -f
+
+  # The preboot will be always active, only when the label “migration” is present will be disabled.
+  # TODO: Once tested, 'staging_3' must be chenged bye 'production'
+  if  [ "${DEPLOY_ENVIRONMENT}" = "staging_3" ] && [ "${WITH_MIGRATION}" = "Y" ]; then
+    heroku features:disable preboot -a ${app_name}
+  fi
+
+  git push https://heroku:${HEROKU_API_KEY}@git.heroku.com/${app_name}.git HEAD:master -f
+
+  # TODO: Once tested, 'staging_3' must be chenged bye 'production'
+  if  [ "${DEPLOY_ENVIRONMENT}" = "staging_3" ] && [ "${WITH_MIGRATION}" = "Y" ]; then
+    heroku features:enable preboot -a ${app_name}
+  fi
 
   echo "...done"
 

--- a/js_build/chat.sh
+++ b/js_build/chat.sh
@@ -7,6 +7,7 @@ main(){
   type=$1
   environment=$2
   err=$3
+  migration=$4
 
   icon=""
   message=""
@@ -25,7 +26,12 @@ main(){
 
   error_message=""
   if [ "$err" != "" ]; then
-    error_message="Motive:              *${err}*"
+    error_message="Motive:              *${err}*\n"
+  fi
+
+  migration_message=""
+  if [ "$migration" != "" ]; then
+    migration_message="Migration:          *Yes!*\n"
   fi
 
   number=$(jq --raw-output .number ${GITHUB_EVENT_PATH})
@@ -36,7 +42,7 @@ main(){
   chat=$(curl -s -X POST \
     "https://chat.googleapis.com/v1/spaces/${SPACE}/messages?key=${CKEY}&token=${CTOKEN}" \
     -H 'Content-Type: application/json' \
-    -d "{\"text\" : \"${icon} ${message} \nEnvironment:    *${environment}* \nProject:              *${GITHUB_REPOSITORY}* \nPull Request:    *${title}* \nDeployer:           *${GITHUB_ACTOR}* \n${error_message} \"}")
+    -d "{\"text\" : \"${icon} ${message} \nEnvironment:    *${environment}* \nProject:              *${GITHUB_REPOSITORY}* \nPull Request:    *${title}* \nDeployer:           *${GITHUB_ACTOR}* \n${error_message}${migration_message} \"}")
 
 }
 

--- a/js_build/entrypoint.sh
+++ b/js_build/entrypoint.sh
@@ -7,8 +7,9 @@ send_chat_message()
   type=$1
   environment=$2
   message=$3
+  migration=$4
 
-  sh -c "$chat_path $type \"$environment\" \"$message\""
+  sh -c "$chat_path $type \"$environment\" \"$message\" \"migration\""
 }
 
 abort()

--- a/label_check/chat.sh
+++ b/label_check/chat.sh
@@ -7,6 +7,7 @@ main(){
   type=$1
   environment=$2
   err=$3
+  migration=$4
 
   icon=""
   message=""
@@ -25,7 +26,12 @@ main(){
 
   error_message=""
   if [ "$err" != "" ]; then
-    error_message="Motive:              *${err}*"
+    error_message="Motive:              *${err}*\n"
+  fi
+
+  migration_message=""
+  if [ "$migration" != "" ]; then
+    migration_message="Migration:          *Yes!*\n"
   fi
 
   number=$(jq --raw-output .number ${GITHUB_EVENT_PATH})
@@ -36,7 +42,7 @@ main(){
   chat=$(curl -s -X POST \
     "https://chat.googleapis.com/v1/spaces/${SPACE}/messages?key=${CKEY}&token=${CTOKEN}" \
     -H 'Content-Type: application/json' \
-    -d "{\"text\" : \"${icon} ${message} \nEnvironment:    *${environment}* \nProject:              *${GITHUB_REPOSITORY}* \nPull Request:    *${title}* \nDeployer:           *${GITHUB_ACTOR}* \n${error_message} \"}")
+    -d "{\"text\" : \"${icon} ${message} \nEnvironment:    *${environment}* \nProject:              *${GITHUB_REPOSITORY}* \nPull Request:    *${title}* \nDeployer:           *${GITHUB_ACTOR}* \n${error_message}${migration_message} \"}")
 
 }
 

--- a/label_check/entrypoint.sh
+++ b/label_check/entrypoint.sh
@@ -35,15 +35,16 @@ main(){
 
     echo "DEBUG {\"title\":\"${labels}\", \"head\":\"${branch}\", \"base\": \"staging\"}"
     echo "checking labels ${GITHUB_REPOSITORY}"
-    
+
     issue=$(curl -X GET "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${number}" \
     -H "Authorization: token ${TOKEN}")
 
     echo "${issue}"
- 
+
     labels=$(echo "${issue}" | jq -r .labels)
 
     production_label="deploy"
+    migration_label="migration"
     staging_label="deploy_staging"
     staging_label_two="deploy_staging_2"
     staging_label_three="deploy_staging_3"
@@ -53,9 +54,10 @@ main(){
 
     has_deploy_label="N"
     label_to_check=""
+    has_migration_label="N"
 
     echo "${labels}"
-    
+
     # Reading labels
     for row in $(echo "${labels}" | jq -r '.[] | @base64'); do
         _jq() {
@@ -89,7 +91,14 @@ main(){
             DEPLOY_ENVIRONMENT="staging_3"
             label_to_check=$staging_label_three
         fi
+
+        if [ "$label_name" = "$migration_label" ]; then
+            echo "...with '${migration_label}'..."
+            has_migration_label="Y"
+        fi
     done
+
+    echo "::set-env name=WITH_MIGRATION::${has_migration_label}"
 
     if [[ $production_target = "N" ]]  && [[ $staging_target = "N" ]]; then
         echo "..has no deploy label. Exiting now."
@@ -146,11 +155,11 @@ main(){
     echo ""
     echo ""
     echo "Checking if ${branch} is up to date with master..."
-    
+
     git config remote.origin.url "https://${GITHUB_ACTOR}:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
-    git fetch 
-    
+    git fetch
+
     revision=$(git rev-list --left-right --count origin/master...origin/${branch} | head -c 1)
 
     echo "$(git rev-list --left-right --count origin/master...origin/${branch})"

--- a/label_check/entrypoint.sh
+++ b/label_check/entrypoint.sh
@@ -116,8 +116,7 @@ main(){
         production_target="N"
     fi
 
-    # TODO: Change "$label_to_check = $staging_label_three" to $production_target = "Y"
-    if [ $label_to_check = $staging_label_three ] && [ $has_migration_label = "Y" ]; then
+    if [ $production_target = "Y" ] && [ $has_migration_label = "Y" ]; then
         echo "::set-env name=WITH_MIGRATION::${has_migration_label}"
         migration_message="true"
     fi

--- a/label_check/entrypoint.sh
+++ b/label_check/entrypoint.sh
@@ -7,8 +7,9 @@ send_chat_message()
   type=$1
   environment=$2
   message=$3
+  migration=$4
 
-  sh -c "$chat_path $type \"$environment\" \"$message\""
+  sh -c "$chat_path $type \"$environment\" \"$message\" \"migration\""
 }
 
 abort()
@@ -55,6 +56,7 @@ main(){
     has_deploy_label="N"
     label_to_check=""
     has_migration_label="N"
+    migration_message=""
 
     echo "${labels}"
 
@@ -95,6 +97,7 @@ main(){
         if [ "$label_name" = "$migration_label" ]; then
             echo "...with '${migration_label}'..."
             has_migration_label="Y"
+            migration_message="true"
         fi
     done
 
@@ -119,7 +122,7 @@ main(){
     echo "...done"
 
     type="action"
-    send_chat_message "$type \"$DEPLOY_ENVIRONMENT\""
+    send_chat_message "$type \"$DEPLOY_ENVIRONMENT\" \"\" \"$migration_message\""
 
     # Check if another PR has deploy or deploy_staging label
     echo ""

--- a/label_check/entrypoint.sh
+++ b/label_check/entrypoint.sh
@@ -97,11 +97,8 @@ main(){
         if [ "$label_name" = "$migration_label" ]; then
             echo "...with '${migration_label}'..."
             has_migration_label="Y"
-            migration_message="true"
         fi
     done
-
-    echo "::set-env name=WITH_MIGRATION::${has_migration_label}"
 
     if [[ $production_target = "N" ]]  && [[ $staging_target = "N" ]]; then
         echo "..has no deploy label. Exiting now."
@@ -117,6 +114,12 @@ main(){
             echo "... both production and staging labels found. Staging overrides production..."
         fi
         production_target="N"
+    fi
+
+    # TODO: Change "$label_to_check = $staging_label_three" to $production_target = "Y"
+    if [ $label_to_check = $staging_label_three ] && [ $has_migration_label = "Y" ]; then
+        echo "::set-env name=WITH_MIGRATION::${has_migration_label}"
+        migration_message="true"
     fi
 
     echo "...done"

--- a/worker_check/chat.sh
+++ b/worker_check/chat.sh
@@ -7,6 +7,7 @@ main(){
   type=$1
   environment=$2
   err=$3
+  migration=$4
 
   icon=""
   message=""
@@ -25,7 +26,12 @@ main(){
 
   error_message=""
   if [ "$err" != "" ]; then
-    error_message="Motive:              *${err}*"
+    error_message="Motive:              *${err}*\n"
+  fi
+
+  migration_message=""
+  if [ "$migration" != "" ]; then
+    migration_message="Migration:          *Yes!*\n"
   fi
 
   number=$(jq --raw-output .number ${GITHUB_EVENT_PATH})
@@ -36,7 +42,7 @@ main(){
   chat=$(curl -s -X POST \
     "https://chat.googleapis.com/v1/spaces/${SPACE}/messages?key=${CKEY}&token=${CTOKEN}" \
     -H 'Content-Type: application/json' \
-    -d "{\"text\" : \"${icon} ${message} \nEnvironment:    *${environment}* \nProject:              *${GITHUB_REPOSITORY}* \nPull Request:    *${title}* \nDeployer:           *${GITHUB_ACTOR}* \n${error_message} \"}")
+    -d "{\"text\" : \"${icon} ${message} \nEnvironment:    *${environment}* \nProject:              *${GITHUB_REPOSITORY}* \nPull Request:    *${title}* \nDeployer:           *${GITHUB_ACTOR}* \n${error_message}${migration_message} \"}")
 
 }
 

--- a/worker_check/entrypoint.sh
+++ b/worker_check/entrypoint.sh
@@ -7,8 +7,9 @@ send_chat_message()
   type=$1
   environment=$2
   message=$3
+  migration=$4
 
-  sh -c "$chat_path $type \"$environment\" \"$message\""
+  sh -c "$chat_path $type \"$environment\" \"$message\" \"migration\""
 }
 
 abort()
@@ -38,7 +39,7 @@ main(){
   token=$INPUT_RAILSTOKEN
 
   environment="${DEPLOY_ENVIRONMENT}"
-  
+
   number=$(jq --raw-output .number ${GITHUB_EVENT_PATH})
   issue=$(curl -X GET "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${number}" \
     -H "Authorization: token ${TOKEN}")
@@ -62,7 +63,7 @@ main(){
 
   echo ""
   echo "STEP 1 OF 2: Holding semaphores..."
-  
+
   if [ -z "${DEPLOY_ENVIRONMENT}" ] || [ "${DEPLOY_ENVIRONMENT}" != "production" ]; then
     echo "...no targeting production deploy"
     echo "ERROR"
@@ -92,7 +93,7 @@ main(){
   echo ""
 
   # Wait
-  
+
   echo "STEP 2 OF 2: Waiting for workers..."
 
   while [[ "$ready" != "true" ]] && [[ $tries -lt 60 ]]


### PR DESCRIPTION
## Summary: [MAN-42](https://loyal-guru.atlassian.net/browse/MAN-42)

Heroku deploys makes stuck the system a few seconds.
To try to solve it, [_preboot_](https://devcenter.heroku.com/articles/preboot) is being added.

A new label should be added to recognize  PR with migrations due to a [Heroku warning](https://devcenter.heroku.com/articles/preboot#deploying-with-preboot)
> If you make database schema changes that require downtime, we recommend disabling the preboot feature, performing the changes and code push as usual, then re-enabling preboot.


### Actions

- Add a new label
    - Label: `migration`
- PR with the `migration` label will be executed without _preboot_.
   > When the `migration` label is present, it'll be disabled before and be re-enabled after the deploy.
- _preboot_ will be always active

***

> Related: [[MANAGEMENT] 'HEROKU_API_KEY' set as environment to use Heroku CLI ](https://github.com/loyalguru/loyal-guru-api/pull/3683)