### PR TITLE
Deployment using Makefile support

### DIFF
--- a/gcloud_deploy/Dockerfile
+++ b/gcloud_deploy/Dockerfile
@@ -6,7 +6,8 @@ RUN	apk add --no-cache \
 	curl \
 	curl-dev \
 	jq \
-	coreutils
+	coreutils \
+	make
 
 ADD chat.sh /chat.sh
 RUN chmod +x /chat.sh

--- a/gcloud_deploy/entrypoint.sh
+++ b/gcloud_deploy/entrypoint.sh
@@ -89,6 +89,9 @@ main(){
     command_argument=''
   fi
   command="gcloud app deploy app.yaml --quiet $command_argument"
+  if [ "${INPUT_MAKEFILE_DEPLOYMENT}" = "true" ]; then
+    command="make publish-version"
+  fi
   sh -c "$command"
 
   echo "...done!"


### PR DESCRIPTION
This PR allows us to deploy using a Makefile command. Why? Because FQS service was created and designed to use a different CI pipeline (image is built and deployed from CircleCI).

To avoid doing a big rework there, I chose to add a small change here, isolated by a new and specific environment variable.

This changes is required to be able to deploy using labels in fast-query-service. Related PR: https://github.com/loyalguru/fast-query-service/pull/22