### PR TITLE
Change Flag when building project

### DIFF
--- a/js_build/entrypoint.sh
+++ b/js_build/entrypoint.sh
@@ -61,7 +61,7 @@ main(){
 
   NG_PATH=$(command -v ng)
 
-  node --max_old_space_size=4000 "$NG_PATH" build --env "$DEPLOY_ENVIRONMENT" --aot
+  node --max_old_space_size=4000 "$NG_PATH" build -c "$DEPLOY_ENVIRONMENT" --aot
 
   echo "..done"
   echo ""


### PR DESCRIPTION
since we move to angular v7, use of flag --env is deprecated. We must use -c instead of --env when building our project.

Ex. ng serve -c {{ENVIRONMENT}}